### PR TITLE
Update Changelog 17.09.2023

### DIFF
--- a/changelog/2023-09/17.md
+++ b/changelog/2023-09/17.md
@@ -33,4 +33,4 @@ layout:
 * Fehler behoben, durch den die Werte in `/casino daily` vertauscht waren
 * Counting funktioniert jetzt wieder korrekt
 * Man kann jetzt nicht mehr an Gewinnspielen teilnehmen, die bereits beendet sind
-* Fehler behoben, durch den Cooldowns nicht auf alle Mitglieder angewendet wurden
+* Fehler behoben, durch den wenn man im Cooldown ist und trotzdem einen Command ausführt, der Cooldown noch einmal für alle Mitglieder dazu gerechnet wurde


### PR DESCRIPTION
@kollhdxdlp hat einen Fehler im Changelog für KW 37 gemeldet.
Er betrifft den letzten Punkt, in dem vorher stand, dass der Cooldown nicht auf alle Mitglieder angewendet wurde. Das ist aber falsch ausgedrückt. Es war nämlich so, dass wenn man im Cooldown ist und trotzdem versucht, einen Command zu verwenden, wird der Cooldown noch einmal ***für alle Mitglieder*** dazu gerechnet.

Diese Formulierung wurde in dieser Version des Changelogs angepasst.